### PR TITLE
拡張機能のバックエンドの URL を環境変数で定義

### DIFF
--- a/webext/README.md
+++ b/webext/README.md
@@ -19,8 +19,9 @@ yarn run watch
 
 ## 環境変数
 
-Twitter API を利用して取得する場合は `.env` に以下を記述します。
+Twitter API を利用して取得する場合は `.env` の `USE_API` を `true` に設定します。
 
 ```
+BACKEND_URL=http://localhost:3030
 USE_API=true
 ```

--- a/webext/public/manifest.firefox.json
+++ b/webext/public/manifest.firefox.json
@@ -13,5 +13,5 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "permissions": ["http://localhost/*"]
+  "permissions": ["$BACKEND_URL/*"]
 }

--- a/webext/public/manifest.json
+++ b/webext/public/manifest.json
@@ -13,5 +13,5 @@
   "background": {
     "service_worker": "background.js"
   },
-  "host_permissions": ["http://localhost:3030/*"]
+  "host_permissions": ["$BACKEND_URL/*"]
 }

--- a/webext/src/background.ts
+++ b/webext/src/background.ts
@@ -1,7 +1,7 @@
 import { MessageRequest, MessageResponse } from './request';
 import browser from 'webextension-polyfill';
 
-const BACKEND_URL = 'http://localhost:3030';
+const backendUrl = process.env.BACKEND_URL;
 
 const generateErrorMessage = (
   type: 'serverError' | 'networkError' | 'invalidMessage'
@@ -25,7 +25,7 @@ browser.runtime.onMessage.addListener(
         'id' in message.body
       ) {
         try {
-          const response = await fetch(`${BACKEND_URL}/tweet`, {
+          const response = await fetch(`${backendUrl}/tweet`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -54,7 +54,7 @@ browser.runtime.onMessage.addListener(
         ].every((field) => field in message.body)
       ) {
         try {
-          const response = await fetch(`${BACKEND_URL}/parsed-tweet`, {
+          const response = await fetch(`${backendUrl}/parsed-tweet`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -72,7 +72,7 @@ browser.runtime.onMessage.addListener(
       // get the stored tweet list
       if (message.type === 'get-tweets') {
         try {
-          const response = await fetch(`${BACKEND_URL}/tweet`, {
+          const response = await fetch(`${backendUrl}/tweet`, {
             method: 'GET',
           });
           if (!response.ok) {

--- a/webext/webpack.config.js
+++ b/webext/webpack.config.js
@@ -5,7 +5,10 @@ const { DefinePlugin, EnvironmentPlugin } = require('webpack');
 const process = require('process');
 
 module.exports = () => {
-  const env = dotenv.config().parsed || { USE_API: 'false' };
+  const env = dotenv.config().parsed || {
+    BACKEND_URL: 'http://localhost:3030',
+    USE_API: 'false',
+  };
 
   return {
     mode: process.env.NODE_ENV || 'development',
@@ -33,11 +36,22 @@ module.exports = () => {
     plugins: [
       new EnvironmentPlugin(['TARGET_BROWSER']),
       new CopyPlugin({
+        patterns: [{ from: 'public/style.css' }],
+      }),
+      new CopyPlugin({
         patterns: [
-          { from: 'public/style.css' },
-          process.env.TARGET_BROWSER === 'firefox'
-            ? { from: 'public/manifest.firefox.json', to: 'manifest.json' }
-            : { from: 'public/manifest.json' },
+          {
+            from:
+              process.env.TARGET_BROWSER === 'firefox'
+                ? 'public/manifest.firefox.json'
+                : 'public/manifest.json',
+            to: 'manifest.json',
+            transform(content) {
+              return content
+                .toString()
+                .replace('$BACKEND_URL', process.env.BACKEND_URL);
+            },
+          },
         ],
       }),
       new DefinePlugin({


### PR DESCRIPTION
fix: #23 
`.env` に `BACKEND_URL` を書くことで指定できるようにしました。
初期値は http://localhost:3030 です